### PR TITLE
try to open Chrome

### DIFF
--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -70,7 +70,12 @@ export default class Home extends React.Component<IProps, IState> {
         <div
           className={styleButton}
           onClick={() => {
-            window.location.replace(content);
+            try {
+              window.open(`googlechrome://navigate?url=${content}`);
+            } catch (error) {
+              console.error("Failed to open Chrome", error);
+              window.open(content);
+            }
           }}
         >
           Open


### PR DESCRIPTION
Windows opened with `window.open(x)` can not be closed. Very weird. Windows opened with `googlechrome://` can be closed now. Now sure if this is a solid solution.
